### PR TITLE
Add top-level replicate function 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ to load a specific corestore. If you do not pass a namespace a random one is gen
 
 The remote corestore network instance.
 
+#### `client.replicate(core)`
+
+A one-line replication function for `RemoteHypercores` (see below for details).
+
 ## Remote Corestore
 
 The remote corestore instances has an API that mimicks the normal [corestore](https://github.com/andrewosh/corestore) API.
@@ -104,9 +108,9 @@ Emitted when a peer is added.
 
 Emitted when a peer is removed.
 
-#### `await network.configure(discoveryKey, options)`
+#### `await network.configure(discoveryKey | RemoteHypercore, options)`
 
-Configure the network for this specific discovery key.
+Configure the network for this specific discovery key or RemoteHypercore.
 Options include:
 
 ```
@@ -224,6 +228,14 @@ Emitted when the feed is appended to, either locally or remotely.
 #### `feed.on('download', seq)`
 
 Emitted when a block is downloaded.
+
+## Replicator
+
+Hyperspace also includes a simple replication function for `RemoteHypercores` that does two things:
+1. It first configures the network (`client.network.configure(core, { announce: true, lookup: true })`)
+2. Then it does a `core.update({ ifAvailable: true })` to try to fetch the latest length from the network.
+
+This saves a bit of time when swarming a `RemoteHypercore`.
 
 # License
 

--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ class RemoteNetworker extends EventEmitter {
   async _configure (discoveryKey, opts) {
     if (typeof discoveryKey === 'object' && !Buffer.isBuffer(discoveryKey)) {
       const core = discoveryKey
-      await core.ready()
+      if (!core.discoveryKey) await core.ready()
       discoveryKey = core.discoveryKey
     }
     return this._client.network.configure({

--- a/index.js
+++ b/index.js
@@ -228,7 +228,6 @@ class RemoteNetworker extends EventEmitter {
   }
 
   async _configure (discoveryKey, opts) {
-    console.log('discovery key:', discoveryKey)
     if (typeof discoveryKey === 'object' && !Buffer.isBuffer(discoveryKey)) {
       const core = discoveryKey
       await core.ready()
@@ -254,10 +253,8 @@ class RemoteNetworker extends EventEmitter {
   }
 
   configure (discoveryKey, opts = {}, cb) {
-    console.log('CONFIGURING')
     const configureProm = this._configure(discoveryKey, opts)
     maybeOptional(cb, configureProm)
-    configureProm.then(() => console.log('!! CONFIGURED'))
     return configureProm
   }
 

--- a/index.js
+++ b/index.js
@@ -854,7 +854,7 @@ module.exports = class HyperspaceClient {
     this.network = new RemoteNetworker({ client: this._client, sessions })
     this.corestore = (name) => this._corestore.namespace(name)
     // Exposed like this so that you can destructure: const { replicate } = new Client()
-    this.replicate = (core, cb) => this._replicate(core, cb)
+    this.replicate = (core, cb) => maybe(cb, this._replicate(core))
   }
 
   static async serverReady (opts) {
@@ -891,22 +891,16 @@ module.exports = class HyperspaceClient {
     return maybe(cb, this.network.ready())
   }
 
-  async _replicate (core, cb) {
-    try {
-      await this.network.configure(core, {
-        announce: true,
-        lookup: true
-      })
-    } catch (err) {
-      if (cb) return cb(err)
-      throw err
-    }
+  async _replicate (core) {
+    await this.network.configure(core, {
+      announce: true,
+      lookup: true
+    })
     try {
       await core.update({ ifAvailable: true })
     } catch (_) {
       // If this update fails, the error can be ignored.
     }
-    if (cb) return cb(null)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -854,7 +854,7 @@ module.exports = class HyperspaceClient {
     this.network = new RemoteNetworker({ client: this._client, sessions })
     this.corestore = (name) => this._corestore.namespace(name)
     // Exposed like this so that you can destructure: const { replicate } = new Client()
-    this.replicate = (core, cb) => maybe(cb, this._replicate(core))
+    this.replicate = (core, cb) => maybeOptional(cb, this._replicate(core))
   }
 
   static async serverReady (opts) {


### PR DESCRIPTION
This PR adds a top-level `replicate` function to the Hyperspace client that streamlines the process of connecting a `RemoteHypercore` with peers.

It does two things:
1. Calls `network.configure(core, { announce: true, lookup: true })`
2. Does a `core.update({ ifAvailable: true })` and suppresses any "Blocks not available from peers" errors.

The PR also extends the `network.configure` method to accept `RemoteHypercores` as a first argument.