### PR TITLE
Switch upload/download to using a pseudo-buffer instead of a third byteLength param

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,13 +225,13 @@ Emitted when a peer is removed.
 
 Emitted when the feed is appended to, either locally or remotely.
 
-#### `feed.on('download', seq, data, byteLength)`
+#### `feed.on('download', seq, data)`
 
-Emitted when a block is downloaded. Currently `data` is null and is only present for backwards compatibility.
+Emitted when a block is downloaded. `data` is a pseudo-buffer with `{length, byteLength}` but no buffer content.
 
-#### `feed.on('upload', seq, data, byteLength)`
+#### `feed.on('upload', seq, data)`
 
-Emitted when a block is uploaded. Currently `data` is null and is only present for backwards compatibility.
+Emitted when a block is uploaded. `data` is a pseudo-buffer with `{length, byteLength}` but no buffer content.
 
 ## Replicator
 

--- a/index.js
+++ b/index.js
@@ -493,12 +493,12 @@ class RemoteHypercore extends Nanoresource {
 
   _ondownload (rsp) {
     // TODO: Add to local bitfield?
-    this.emit('download', rsp.seq, null, rsp.byteLength)
+    this.emit('download', rsp.seq, {length: rsp.byteLength, byteLength: rsp.byteLength})
   }
 
   _onupload (rsp) {
     // TODO: Add to local bitfield?
-    this.emit('upload', rsp.seq, null, rsp.byteLength)
+    this.emit('upload', rsp.seq, {length: rsp.byteLength, byteLength: rsp.byteLength})
   }
 
   // Private Methods


### PR DESCRIPTION
Turns out that hypercore uses the third param of the `download/upload` events to specify a peer. To maintain compat, we're going to have hyperspace-client emit an object that is "buffer-like" -- it contains no data but has the `length` and `byteLength` params set.